### PR TITLE
fixed import path for unit tests

### DIFF
--- a/test/monoidal-reducible.js
+++ b/test/monoidal-reducible.js
@@ -1,7 +1,7 @@
 import * as assert from "assert"
 
 import * as AST from "laserbat-ast"
-import reduce, {MonoidalReducible} from "."
+import reduce, {MonoidalReducible} from "../"
 
 suite("MonoidalReducible", () => {
 


### PR DESCRIPTION
When running `npm test` at the repo root, the tests were failing unless the imported module was specified as '..'

Actual:

``` shell
$ npm test
npm info it worked if it ends with ok
npm info using npm@2.1.9
npm info using node@v0.10.28
npm info pretest laserbat-reducer@0.0.1
npm info test laserbat-reducer@0.0.1

> laserbat-reducer@0.0.1 test ~/development/src/laserbat-reducer-js
> mocha --compilers js:6to5/lib/6to5/register --inline-diffs --check-leaks --ui tdd --reporter dot test

Error: Cannot find module '.'
    at Function.Module._resolveFilename (module.js:338:15)
    at Function.Module._load (module.js:280:25)
    at Module.require (module.js:364:17)
    at require (module.js:380:17)
    at Object.<anonymous> (~/development/src/laserbat-reducer-js/test/monoidal-reducible.js:4:14)
    at Module._compile (module.js:456:26)
    at Object.loader (~/development/src/laserbat-reducer-js/node_modules/6to5/lib/6to5/register.js:103:5)
    at Module.load (module.js:356:32)
    at Function.Module._load (module.js:312:12)
    at Module.require (module.js:364:17)
    at require (module.js:380:17)
    at ~/development/src/laserbat-reducer-js/node_modules/mocha/lib/mocha.js:184:27
    at Array.forEach (native)
    at Mocha.loadFiles (~/development/src/laserbat-reducer-js/node_modules/mocha/lib/mocha.js:181:14)
    at Mocha.run (~/development/src/laserbat-reducer-js/node_modules/mocha/lib/mocha.js:393:31)
    at Object.<anonymous> (~/development/src/laserbat-reducer-js/node_modules/mocha/bin/_mocha:380:16)
    at Module._compile (module.js:456:26)
    at Object.Module._extensions..js (module.js:474:10)
    at Module.load (module.js:356:32)
    at Function.Module._load (module.js:312:12)
    at Function.Module.runMain (module.js:497:10)
    at startup (node.js:119:16)
    at node.js:906:3
npm info laserbat-reducer@0.0.1 Failed to exec test script
npm ERR! Test failed.  See above for more details.
```

After fix:

``` shell
$ npm test
npm info it worked if it ends with ok
npm info using npm@2.1.9
npm info using node@v0.10.28
npm info pretest laserbat-reducer@0.0.1
npm info test laserbat-reducer@0.0.1

> laserbat-reducer@0.0.1 test ~/development/src/laserbat-reducer-js
> mocha --compilers js:6to5/lib/6to5/register --inline-diffs --check-leaks --ui tdd --reporter dot test



  ․

  1 passing (4ms)

npm info posttest laserbat-reducer@0.0.1
npm info ok
```
