### PR TITLE
Add some common monoidal reducers

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -23,3 +23,4 @@ export { default as LazyCloneReducer } from './lazy-clone-reducer.js';
 export { default as MonoidalReducer } from './monoidal-reducer.js';
 export { default as ThunkedMonoidalReducer } from './thunked-monoidal-reducer.js';
 export { default as adapt } from './adapt.js';
+export { PlusReducer, ThunkedPlusReducer, ConcatReducer, ThunkedConcatReducer, AndReducer, ThunkedAndReducer, OrReducer, ThunkedOrReducer } from './reducers.js';

--- a/src/reducers.js
+++ b/src/reducers.js
@@ -1,0 +1,111 @@
+/*
+ * Copyright 2018 Shape Security, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+'use strict';
+
+import MonoidalReducer from './monoidal-reducer.js';
+import ThunkedMonoidalReducer from './thunked-monoidal-reducer.js';
+
+const PlusMonoid = {
+  empty() {
+    return 0;
+  },
+  concat(other) {
+    return this + other;
+  },
+};
+
+const ConcatMonoid = {
+  empty() {
+    return [];
+  },
+  concat(other) {
+    return this.concat(other);
+  },
+};
+
+const AndMonoid = {
+  empty() {
+    return true;
+  },
+  concat(other) {
+    return this && other;
+  },
+  concatThunk(otherThunk) {
+    return this && otherThunk();
+  },
+};
+
+const OrMonoid = {
+  empty() {
+    return false;
+  },
+  concat(other) {
+    return this || other;
+  },
+  concatThunk(otherThunk) {
+    return this || otherThunk();
+  },
+};
+
+
+export class PlusReducer extends MonoidalReducer {
+  constructor() {
+    super(PlusMonoid);
+  }
+}
+
+export class ThunkedPlusReducer extends ThunkedMonoidalReducer {
+  constructor() {
+    super(PlusMonoid);
+  }
+}
+
+export class ConcatReducer extends MonoidalReducer {
+  constructor() {
+    super(ConcatMonoid);
+  }
+}
+
+export class ThunkedConcatReducer extends ThunkedMonoidalReducer {
+  constructor() {
+    super(ConcatMonoid);
+  }
+}
+
+export class AndReducer extends MonoidalReducer {
+  constructor() {
+    super(AndMonoid);
+  }
+}
+
+export class ThunkedAndReducer extends ThunkedMonoidalReducer {
+  constructor() {
+    super(AndMonoid);
+  }
+}
+
+export class OrReducer extends MonoidalReducer {
+  constructor() {
+    super(OrMonoid);
+  }
+}
+
+export class ThunkedOrReducer extends ThunkedMonoidalReducer {
+  constructor() {
+    super(OrMonoid);
+  }
+}


### PR DESCRIPTION
A lot of my uses of the monoidal reducer end up based on one of these. Providing them allows omitting a lot of boilerblate: for example, going from

```js
class HasNullReducer extends ThunkedMonoidalReducer {
  constructor() {
    super({
      empty: () => false,
      concatThunk(a) {
        return this || a();
      },
    });
  }

  reduceLiteralNullExpression() {
    return true;
  }
}
```
to
```js
class HasNullReducer extends ThunkedOrReducer {
  reduceLiteralNullExpression() {
    return true;
  }
}
```

I didn't worry too much about names because I'm sure other people have strong opinions and there are a lot of options. Some common names for the underlying monoid of what this PR calls `OrReducer`, for example:

- [Disjunction](https://github.com/fantasyland/fantasy-monoids/blob/master/src/disjunction.js)
- [BooleanOr](https://github.com/shapesecurity/shape-functional-java/blob/6fb75aa6a8adf25a903f4ec6ef3a1a989ef8c052/src/main/java/com/shapesecurity/functional/data/Monoid.java#L30)
- [Some](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/some)
- [Any](http://hackage.haskell.org/package/base-4.11.0.0/docs/Prelude.html#v:any)

I have no strong preferences. If anyone would like to pick a consistent naming scheme that isn't totally absurd I'll go with that.