### PR TITLE
Switch build scripts to writeFileSync

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules
 npm-debug.log
 dist
+package-lock.json

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,6 @@ script:
   - npm test
   - npm run lint
 node_js:
-  - "4"
   - "6"
   - "8"
+  - "10"

--- a/scripts/build/generate-adapt.js
+++ b/scripts/build/generate-adapt.js
@@ -31,4 +31,4 @@ ${Object.keys(spec).map(typeName => `
 });
 `;
 
-require('fs').writeFile('gen/adapt.js', content, 'utf-8');
+require('fs').writeFileSync('gen/adapt.js', content, 'utf-8');

--- a/scripts/build/generate-clone-reducer.js
+++ b/scripts/build/generate-clone-reducer.js
@@ -53,4 +53,4 @@ for (let [typeName, type] of Object.entries(spec)) {
 content += `}
 `;
 
-require('fs').writeFile('gen/clone-reducer.js', content, 'utf-8');
+require('fs').writeFileSync('gen/clone-reducer.js', content, 'utf-8');

--- a/scripts/build/generate-director.js
+++ b/scripts/build/generate-director.js
@@ -65,5 +65,5 @@ export function ${isThunked ? 'thunkedReduce' : 'reduce'}(reducer, node) {
   return content;
 }
 
-require('fs').writeFile('gen/director.js', buildContent(false), 'utf-8');
-require('fs').writeFile('gen/thunked-director.js', buildContent(true), 'utf-8');
+require('fs').writeFileSync('gen/director.js', buildContent(false), 'utf-8');
+require('fs').writeFileSync('gen/thunked-director.js', buildContent(true), 'utf-8');

--- a/scripts/build/generate-lazy-clone-reducer.js
+++ b/scripts/build/generate-lazy-clone-reducer.js
@@ -96,4 +96,4 @@ for (let [typeName, type] of Object.entries(spec)) {
 content += `}
 `;
 
-require('fs').writeFile('gen/lazy-clone-reducer.js', content, 'utf-8', ()=>{});
+require('fs').writeFileSync('gen/lazy-clone-reducer.js', content, 'utf-8');

--- a/scripts/build/generate-memoize.js
+++ b/scripts/build/generate-memoize.js
@@ -46,4 +46,4 @@ content += `  };
 }
 `;
 
-require('fs').writeFile('gen/memoize.js', content, 'utf-8', ()=>{});
+require('fs').writeFileSync('gen/memoize.js', content, 'utf-8');

--- a/scripts/build/generate-monoidal-reducer.js
+++ b/scripts/build/generate-monoidal-reducer.js
@@ -81,4 +81,4 @@ export default class MonoidalReducer {
 
   return content;
 }
-require('fs').writeFile('gen/monoidal-reducer.js', buildContent(), 'utf-8');
+require('fs').writeFileSync('gen/monoidal-reducer.js', buildContent(), 'utf-8');

--- a/scripts/build/generate-thunked-monoidal-reducer.js
+++ b/scripts/build/generate-thunked-monoidal-reducer.js
@@ -106,4 +106,4 @@ export default class MonoidalReducer {
 
   return content;
 }
-require('fs').writeFile('gen/thunked-monoidal-reducer.js', buildContent(), 'utf-8');
+require('fs').writeFileSync('gen/thunked-monoidal-reducer.js', buildContent(), 'utf-8');

--- a/scripts/build/generate-thunkify.js
+++ b/scripts/build/generate-thunkify.js
@@ -61,5 +61,5 @@ export default function thunkify${isClass ? 'Class' : ''}(reducer${isClass ? 'Cl
 }
 `;
 
-  require('fs').writeFile(`gen/thunkify${isClass ? '-class' : ''}.js`, content, 'utf-8', ()=>{});
+  require('fs').writeFileSync(`gen/thunkify${isClass ? '-class' : ''}.js`, content, 'utf-8');
 });


### PR DESCRIPTION
Calling `writeFile` without a callback, as we were previously doing in a few places, has been deprecated for a while and [started throwing in node 10](https://nodejs.org/api/deprecations.html#deprecations_dep0013_fs_asynchronous_function_without_callback).

There's no real reason not to use the sync APIs here, so we might as well.