### PR TITLE
Fix thunkify

### DIFF
--- a/gen/thunkify-class.js
+++ b/gen/thunkify-class.js
@@ -86,7 +86,7 @@ export default function thunkifyClass(reducerClass) {
     }
 
     reduceCallExpression(node, { callee, arguments: _arguments }) {
-      return super.reduceCallExpression(node, { callee: callee(), _arguments: _arguments.map(n => n()) });
+      return super.reduceCallExpression(node, { callee: callee(), arguments: _arguments.map(n => n()) });
     }
 
     reduceCatchClause(node, { binding, body }) {
@@ -94,7 +94,7 @@ export default function thunkifyClass(reducerClass) {
     }
 
     reduceClassDeclaration(node, { name, super: _super, elements }) {
-      return super.reduceClassDeclaration(node, { name: name(), _super: _super == null ? null : _super(), elements: elements.map(n => n()) });
+      return super.reduceClassDeclaration(node, { name: name(), super: _super == null ? null : _super(), elements: elements.map(n => n()) });
     }
 
     reduceClassElement(node, { method }) {
@@ -102,7 +102,7 @@ export default function thunkifyClass(reducerClass) {
     }
 
     reduceClassExpression(node, { name, super: _super, elements }) {
-      return super.reduceClassExpression(node, { name: name == null ? null : name(), _super: _super == null ? null : _super(), elements: elements.map(n => n()) });
+      return super.reduceClassExpression(node, { name: name == null ? null : name(), super: _super == null ? null : _super(), elements: elements.map(n => n()) });
     }
 
     reduceCompoundAssignmentExpression(node, { binding, expression }) {
@@ -270,7 +270,7 @@ export default function thunkifyClass(reducerClass) {
     }
 
     reduceNewExpression(node, { callee, arguments: _arguments }) {
-      return super.reduceNewExpression(node, { callee: callee(), _arguments: _arguments.map(n => n()) });
+      return super.reduceNewExpression(node, { callee: callee(), arguments: _arguments.map(n => n()) });
     }
 
     reduceNewTargetExpression(node) {

--- a/gen/thunkify.js
+++ b/gen/thunkify.js
@@ -86,7 +86,7 @@ export default function thunkify(reducer) {
     },
 
     reduceCallExpression(node, { callee, arguments: _arguments }) {
-      return reducer.reduceCallExpression(node, { callee: callee(), _arguments: _arguments.map(n => n()) });
+      return reducer.reduceCallExpression(node, { callee: callee(), arguments: _arguments.map(n => n()) });
     },
 
     reduceCatchClause(node, { binding, body }) {
@@ -94,7 +94,7 @@ export default function thunkify(reducer) {
     },
 
     reduceClassDeclaration(node, { name, super: _super, elements }) {
-      return reducer.reduceClassDeclaration(node, { name: name(), _super: _super == null ? null : _super(), elements: elements.map(n => n()) });
+      return reducer.reduceClassDeclaration(node, { name: name(), super: _super == null ? null : _super(), elements: elements.map(n => n()) });
     },
 
     reduceClassElement(node, { method }) {
@@ -102,7 +102,7 @@ export default function thunkify(reducer) {
     },
 
     reduceClassExpression(node, { name, super: _super, elements }) {
-      return reducer.reduceClassExpression(node, { name: name == null ? null : name(), _super: _super == null ? null : _super(), elements: elements.map(n => n()) });
+      return reducer.reduceClassExpression(node, { name: name == null ? null : name(), super: _super == null ? null : _super(), elements: elements.map(n => n()) });
     },
 
     reduceCompoundAssignmentExpression(node, { binding, expression }) {
@@ -270,7 +270,7 @@ export default function thunkify(reducer) {
     },
 
     reduceNewExpression(node, { callee, arguments: _arguments }) {
-      return reducer.reduceNewExpression(node, { callee: callee(), _arguments: _arguments.map(n => n()) });
+      return reducer.reduceNewExpression(node, { callee: callee(), arguments: _arguments.map(n => n()) });
     },
 
     reduceNewTargetExpression(node) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "shift-reducer",
-  "version": "4.4.0",
+  "version": "4.4.1",
   "description": "reducer for the Shift AST format",
   "author": "Shape Security",
   "homepage": "https://github.com/shapesecurity/shift-reducer-js",

--- a/scripts/build/generate-thunkify.js
+++ b/scripts/build/generate-thunkify.js
@@ -50,7 +50,7 @@ export default function thunkify${isClass ? 'Class' : ''}(reducer${isClass ? 'Cl
       return ${base}.reduce${typeName}(node);`;
     } else {
       content += `
-      return ${base}.reduce${typeName}(node, { ${statefulFields.map(f => sanitize(f.name) + ': ' + force(f)).join(', ')} });`;
+      return ${base}.reduce${typeName}(node, { ${statefulFields.map(f => f.name + ': ' + force(f)).join(', ')} });`;
     }
     content += `
     }${isClass ? '' : ','}

--- a/test/thunk.js
+++ b/test/thunk.js
@@ -41,6 +41,7 @@ const sampleTree = parseScript(`
     debugger;
   }
   0;
+  f(1);
 `);
 
 const postorder = [
@@ -51,6 +52,10 @@ const postorder = [
   'Block',
   'BlockStatement',
   'LiteralNumericExpression',
+  'ExpressionStatement',
+  'IdentifierExpression',
+  'LiteralNumericExpression',
+  'CallExpression',
   'ExpressionStatement',
   'Script',
 ];
@@ -64,6 +69,10 @@ const preorder = [
   'Block',
   'DebuggerStatement',
   'ExpressionStatement',
+  'LiteralNumericExpression',
+  'ExpressionStatement',
+  'CallExpression',
+  'IdentifierExpression',
   'LiteralNumericExpression',
 ];
 
@@ -199,6 +208,10 @@ suite('thunk', () => {
       'BlockStatement', // Note: no 'Block' or 'DebuggerStatement'
       'ExpressionStatement',
       'LiteralNumericExpression',
+      'ExpressionStatement',
+      'CallExpression',
+      'IdentifierExpression',
+      'LiteralNumericExpression',
     ]);
   });
 });
@@ -248,6 +261,10 @@ suite('memoize', () => {
         'ExpressionStatement', // Note: the LiteralNullExpression and the Block are not revisited
         'BlockStatement',
         'ExpressionStatement',
+        'LiteralNumericExpression',
+        'ExpressionStatement',
+        'CallExpression',
+        'IdentifierExpression',
         'LiteralNumericExpression',
       ]);
     });


### PR DESCRIPTION
`thunkify` generated reducers which were malformed for node types with properties which are not identifiers. Fix this.

Includes a version bump commit, so please **rebase**, not merge.

Thanks to @ash0080 for [finding this](https://github.com/shapesecurity/shift-reducer-js/issues/47#issuecomment-426377046).